### PR TITLE
Remove MySQL Governor Blocker

### DIFF
--- a/lib/Elevate/Blockers/Databases.pm
+++ b/lib/Elevate/Blockers/Databases.pm
@@ -32,7 +32,6 @@ sub check ($self) {
     $ok = 0 unless $self->_blocker_acknowledge_postgresql_datadir;
     $ok = 0 unless $self->_blocker_old_mysql;
     $ok = 0 unless $self->_blocker_mysql_upgrade_in_progress;
-    $ok = 0 unless $self->_blocker_mysql_governor;
     $self->_warning_mysql_not_enabled();
     return $ok;
 }
@@ -172,21 +171,6 @@ sub _blocker_old_mysql ( $self, $mysql_version = undef ) {
 sub _blocker_mysql_upgrade_in_progress ($self) {
     if ( -e q[/var/cpanel/mysql_upgrade_in_progress] ) {
         return $self->has_blocker(q[MySQL upgrade in progress. Please wait for the MySQL upgrade to finish.]);
-    }
-
-    return 0;
-}
-
-sub _blocker_mysql_governor ($self) {
-
-    if ( Cpanel::Pkgr::is_installed('governor-mysql') ) {
-        return $self->has_blocker( <<~'EOS' );
-You have MySQL Governor installed.  Upgrades with this software in place are not currently supported.
-For more information regarding MySQL Governor, please review the documentation:
-
-    https://docs.cloudlinux.com/shared/cloudlinux_os_components/#mysql-governor
-
-EOS
     }
 
     return 0;


### PR DESCRIPTION
Case RE-153: Remove the MySQL Governor blocker as the first step in adding specific database support for CloudLinux upgrades.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

