### PR TITLE
Skip Database components if DB software is provided by CL

### DIFF
--- a/lib/Elevate/Blockers/Leapp.pm
+++ b/lib/Elevate/Blockers/Leapp.pm
@@ -34,6 +34,7 @@ sub check ($self) {
     my $blockers = $self->cpev->leapp->search_report_file_for_blockers(
         qw(
           check_installed_devel_kernels
+          cl_mysql_repository_setup
           verify_check_results
         )
     );


### PR DESCRIPTION
Case RE-153: CL leapp supports updating CL versions of MySQL/MariaDB/Percona, so we do not need to remove the database packages provided by CL when we detect that CL MySQL is in use as leapp will handle this.  However, MySQL Governor does leave the cPanel/upstream repo files in place as well as the package that provides the repo files installed when it replaces cPanel/upstream MySQL with CL MySQL.  This leads to an inhibitor in the leapp preupgrade blocker check that we perform.  This change adds this inhibitor to the ignore list and adds a minimal pre_leapp component to remove the packages that provide the repo files when CL MySQL is detected.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

