### PR TITLE
Refactor shared logic between EA4 blocker and component to a library

### DIFF
--- a/lib/Elevate/Blockers/EA4.pm
+++ b/lib/Elevate/Blockers/EA4.pm
@@ -12,7 +12,7 @@ Blocker to check EasyApache profile compatibility.
 
 use cPstrict;
 
-use Elevate::Constants ();
+use Elevate::EA4       ();
 use Elevate::StageFile ();
 
 use parent qw{Elevate::Blockers::Base};
@@ -39,8 +39,9 @@ sub _blocker_ea4_profile ($self) {
 
     INFO("Checking EasyApache profile compatibility with $pretty_distro_name.");
 
-    $self->cpev->component('EA4')->backup;                        # _backup_ea4_profile();
-    my $stash        = Elevate::StageFile::read_stage_file();     # FIXME - move it to a function
+    Elevate::EA4::backup();
+
+    my $stash        = Elevate::StageFile::read_stage_file();
     my $dropped_pkgs = $stash->{'ea4'}->{'dropped_pkgs'} // {};
     return unless scalar keys $dropped_pkgs->%*;
 

--- a/lib/Elevate/Components/Base.pm
+++ b/lib/Elevate/Components/Base.pm
@@ -30,7 +30,6 @@ BEGIN {
     my @_DELEGATE_TO_CPEV = qw{
       getopt
       upgrade_to_pretty_name
-      tmp_dir
       should_run_leapp
       ssystem
       ssystem_and_die

--- a/lib/Elevate/Components/EA4.pm
+++ b/lib/Elevate/Components/EA4.pm
@@ -12,40 +12,16 @@ Perform am EA4 backup pre-elevate then restore it after the elevation process.
 
 use cPstrict;
 
-use Elevate::Constants ();
-use Elevate::OS        ();
-use Elevate::RPM       ();
+use Elevate::EA4       ();
 use Elevate::StageFile ();
-use Elevate::YUM       ();
 
-use Cwd           ();
 use Log::Log4perl qw(:easy);
 
-use Cpanel::JSON            ();
-use Cpanel::Pkgr            ();
-use Cpanel::SafeRun::Simple ();
-
 use parent qw{Elevate::Components::Base};
-
-use Elevate::Blockers ();
-
-##
-## Call early so we can use a blocker based on existing ea4 profile
-##
-
-# note: the backup process is triggered by Elevate::Blockers::EA4
-sub backup ($self) {    # run by the check (should be a dry run mode)
-
-    $self->_backup_ea4_profile;
-    $self->_backup_ea_addons;
-
-    return;
-}
 
 sub pre_leapp ($self) {    # run to perform the backup
 
     $self->run_once('_backup_ea4_profile');
-    $self->run_once('_backup_ea_addons');
     $self->run_once('_backup_config_files');
     $self->run_once('_cleanup_rpm_db');
 
@@ -73,6 +49,11 @@ sub post_leapp ($self) {
     return;
 }
 
+sub _backup_ea4_profile ($self) {
+    Elevate::EA4::backup();
+    return;
+}
+
 sub _cleanup_rpm_db ($self) {
 
     # remove all ea- packages
@@ -92,94 +73,6 @@ sub _restore_ea_addons ($self) {
     $self->ssystem_and_die(qw{/usr/bin/yum install -y ea-nginx});
 
     return;
-}
-
-sub _backup_ea_addons ($self) {
-
-    if ( Cpanel::Pkgr::is_installed('ea-nginx') ) {
-        Elevate::StageFile::update_stage_file( { ea4 => { nginx => 1 } } );
-    }
-    else {
-        Elevate::StageFile::update_stage_file( { ea4 => { nginx => 0 } } );
-    }
-
-    return;
-}
-
-sub _backup_ea4_profile ($self) {    ## _backup_ea4_profile
-
-    my $use_ea4 = Cpanel::Config::Httpd::is_ea4() ? 1 : 0;
-
-    Elevate::StageFile::remove_from_stage_file('ea4');
-    Elevate::StageFile::update_stage_file( { ea4 => { enable => $use_ea4 } } );
-
-    unless ($use_ea4) {
-
-        WARN('Skipping EA4 backup. EA4 does not appear to be enabled on this system');
-
-        return;
-    }
-
-    my $json_path = $self->_get_ea4_profile();
-
-    my $data = { profile => $json_path };
-
-    # store dropped packages
-    my $profile = eval { Cpanel::JSON::LoadFile($json_path) } // {};
-    if ( ref $profile->{os_upgrade} && ref $profile->{os_upgrade}->{dropped_pkgs} ) {
-        $data->{dropped_pkgs} = $profile->{os_upgrade}->{dropped_pkgs};
-    }
-
-    Elevate::StageFile::update_stage_file( { ea4 => $data } );    # FIXME
-
-    return 1;
-}
-
-sub _get_ea4_profile ($self) {
-
-    my $ea_alias = Elevate::OS::ea_alias();
-
-    my @cmd = ( '/usr/local/bin/ea_current_to_profile', "--target-os=$ea_alias" );
-
-    my $profile_file;
-
-    if ( Elevate::Blockers->is_check_mode() ) {
-
-        # use a temporary file in check mode
-        $profile_file = $self->tmp_dir() . '/ea_profile.json';
-        push @cmd, "--output=$profile_file";
-    }
-
-    my $cmd_str = join( ' ', @cmd );
-
-    INFO("Running: $cmd_str");
-    my $output = Cpanel::SafeRun::Simple::saferunnoerror(@cmd) // '';
-    die qq[Unable to backup EA4 profile. Failure from $cmd_str] if $?;
-
-    if ( !$profile_file ) {
-
-        # parse the output to find the profile file...
-
-        my @lines = split( "\n", $output );
-
-        if ( scalar @lines == 1 ) {
-            $profile_file = $lines[0];
-        }
-        else {
-            foreach my $l ( reverse @lines ) {
-                next unless $l =~ m{^/.*\.json};
-                if ( -f $l ) {
-                    $profile_file = $l;
-                    last;
-                }
-            }
-        }
-    }
-
-    die "Unable to backup EA4 profile running: $cmd_str" unless length $profile_file && -f $profile_file && -s _;
-    INFO("Backed up EA4 profile to $profile_file");
-
-    return $profile_file;
 }
 
 sub _restore_ea4_profile ($self) {

--- a/lib/Elevate/EA4.pm
+++ b/lib/Elevate/EA4.pm
@@ -1,0 +1,125 @@
+package Elevate::EA4;
+
+=encoding utf-8
+
+=head1 NAME
+
+Elevate::EA4
+
+Logic to backup and restore EA4 profiles
+
+=cut
+
+use cPstrict;
+
+use File::Temp ();
+
+use Elevate::Blockers  ();
+use Elevate::OS        ();
+use Elevate::StageFile ();
+
+use Cpanel::Config::Httpd   ();
+use Cpanel::JSON            ();
+use Cpanel::Pkgr            ();
+use Cpanel::SafeRun::Simple ();
+
+use Log::Log4perl qw(:easy);
+
+sub backup () {
+    Elevate::EA4::_backup_ea4_profile();
+    Elevate::EA4::_backup_ea_addons();
+    return;
+}
+
+sub _backup_ea4_profile () {
+
+    my $use_ea4 = Cpanel::Config::Httpd::is_ea4() ? 1 : 0;
+
+    Elevate::StageFile::remove_from_stage_file('ea4');
+    Elevate::StageFile::update_stage_file( { ea4 => { enable => $use_ea4 } } );
+
+    unless ($use_ea4) {
+        WARN('Skipping EA4 backup. EA4 does not appear to be enabled on this system');
+        return;
+    }
+
+    my $json_path = Elevate::EA4::_get_ea4_profile();
+
+    my $data = { profile => $json_path };
+
+    # store dropped packages
+    my $profile = eval { Cpanel::JSON::LoadFile($json_path) } // {};
+    if ( ref $profile->{os_upgrade} && ref $profile->{os_upgrade}->{dropped_pkgs} ) {
+        $data->{dropped_pkgs} = $profile->{os_upgrade}->{dropped_pkgs};
+    }
+
+    Elevate::StageFile::update_stage_file( { ea4 => $data } );
+
+    return;
+}
+
+sub _get_ea4_profile () {
+
+    my $ea_alias = Elevate::OS::ea_alias();
+
+    my @cmd = ( '/usr/local/bin/ea_current_to_profile', "--target-os=$ea_alias" );
+
+    my $profile_file;
+    if ( Elevate::Blockers->is_check_mode() ) {
+
+        # use a temporary file in check mode
+        $profile_file = Elevate::EA4::tmp_dir() . '/ea_profile.json';
+        push @cmd, "--output=$profile_file";
+    }
+
+    my $cmd_str = join( ' ', @cmd );
+
+    INFO("Running: $cmd_str");
+    my $output = Cpanel::SafeRun::Simple::saferunnoerror(@cmd) // '';
+    die qq[Unable to backup EA4 profile. Failure from $cmd_str] if $?;
+
+    if ( !$profile_file ) {
+
+        # parse the output to find the profile file...
+
+        my @lines = split( "\n", $output );
+
+        if ( scalar @lines == 1 ) {
+            $profile_file = $lines[0];
+        }
+        else {
+            foreach my $l ( reverse @lines ) {
+                next unless $l =~ m{^/.*\.json};
+                if ( -f $l ) {
+                    $profile_file = $l;
+                    last;
+                }
+            }
+        }
+    }
+
+    die "Unable to backup EA4 profile running: $cmd_str" unless length $profile_file && -f $profile_file && -s _;
+    INFO("Backed up EA4 profile to $profile_file");
+
+    return $profile_file;
+}
+
+my $tmp_dir;
+
+sub tmp_dir () {
+    return $tmp_dir //= File::Temp->newdir();    # auto cleanup on destroy
+}
+
+sub _backup_ea_addons () {
+
+    if ( Cpanel::Pkgr::is_installed('ea-nginx') ) {
+        Elevate::StageFile::update_stage_file( { ea4 => { nginx => 1 } } );
+    }
+    else {
+        Elevate::StageFile::update_stage_file( { ea4 => { nginx => 0 } } );
+    }
+
+    return;
+}
+
+1;

--- a/script/elevate-cpanel.PL
+++ b/script/elevate-cpanel.PL
@@ -207,7 +207,6 @@ use File::Find            ();
 use File::Path            ();
 use File::Slurper         ();
 use File::Spec            ();
-use File::Temp            ();
 use Hash::Merge           ();
 use IO::Prompt            ();
 use Term::ANSIColor       ();
@@ -287,6 +286,7 @@ use Elevate::OS::CloudLinux7 ();
 use Elevate::OS::RHEL        ();
 
 use Elevate::Database         ();
+use Elevate::EA4              ();
 use Elevate::Fetch            ();
 use Elevate::Leapp            ();
 use Elevate::Logger           ();
@@ -1350,10 +1350,6 @@ sub clear_cpanel_caches ($self) {
     unlink $_ foreach @files;
 
     return;
-}
-
-sub tmp_dir ($self) {
-    return $self->{tmp} //= File::Temp->newdir();    # auto cleanup on destroy
 }
 
 my $yum_list_cache;


### PR DESCRIPTION
Case RE-313:  The change refactors the logic for EA4 that is shared between the EA4 blocker and the EA4 component into a library so that the blocker is not calling into the component.

Changelog:

By submitting pull requests to this repo, I agree to the Contributor License Agreement which can be found at: https://github.com/cpanel/elevate/blob/main/docs/cPanel-CLA.pdf

